### PR TITLE
Removed package with dependency problems

### DIFF
--- a/vagrant/CentOS7/Vagrantfile
+++ b/vagrant/CentOS7/Vagrantfile
@@ -13,7 +13,7 @@ $install_nemea = <<SCRIPT
 rpm -ivh https://homeproj.cesnet.cz/rpm/liberouter/devel/x86_64/liberouter-devel-1.0.0-1.noarch.rpm
 wget -O /etc/yum.repos.d/cesnet-nemea.repo https://copr.fedorainfracloud.org/coprs/g/CESNET/NEMEA/repo/epel-7/group_CESNET-NEMEA-epel-7.repo
 rpm --import https://copr-be.cloud.fedoraproject.org/results/@CESNET/NEMEA/pubkey.gpg
-yum install -y nemea nemea-cesnet-modules ipfixcol ipfixcol-unirec-output
+yum install -y nemea nemea-framework-devel ipfixcol ipfixcol-unirec-output
 SCRIPT
 
 $run_supervisor = <<SCRIPT


### PR DESCRIPTION
Vagrant provisioning failed on:
```
Transaction check error:
   file /usr/bin/nemea/ipv6stats from install of nemea-cesnet-modules-1.2.2-1.x86_64 conflicts with file from package nemea-modules-2.6.1-1.x86_64
```
Instead of `nemea-cesnet-modules` use `nemea-framework-devel`.